### PR TITLE
Only reset the admin password to spotweb when the admin has never logged in

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,9 +36,9 @@ E.g. to configure server with host `some.external.mysql-server.com` and port `66
 ## Docker setup
 
 I decided on the following setup for this Docker image:
-* Image contains NGINX, PHP 7.1 and Crond
-* For the database a MySQL image is used
-* To prevent having to configure Spotweb manually `upgrade-db.php` is run to upgrade the database and reset the password for the admin user (so currently the `admin` always has password `spotweb`)
+* Image contains NGINX, PHP 7.2 and Crond
+* For the database a MySQL 5.x image is used (my experience is that MySQL 8 is not working correctly with Spotweb at this moment)
+* To prevent having to configure Spotweb manually `upgrade-db.php` is run to upgrade the database and reset the password for the admin user (so currently the `admin` always has password `spotweb`, you can change this after the first login)
 * Crond is used to run the `retrieve.php` script which updates Spotweb with the latest headers from a configured usenet server, the crontab is run every hour
 * The only required manual configuration is setting up a valid usenet server
 * Depending on what you like, you can mount the /nzb volume and let Spotweb save nzb's to that directory (e.g. mount /nzb to a folder watched by sabnzbd)

--- a/rootfs/etc/cont-init.d/40-initialize-db
+++ b/rootfs/etc/cont-init.d/40-initialize-db
@@ -1,7 +1,18 @@
 #!/usr/bin/with-contenv bash
 
+mysql_host="${DB_HOST:-mysql}"
+mysql_port="${DB_PORT:-3306}"
+mysql_user="${DB_USER:-spotweb}"
+mysql_pass="${DB_PASS:-spotweb}"
+mysql_db="${DB_NAME:-spotweb}"
+
 # upgrade the db
 s6-setuidgid abc php /app/bin/upgrade-db.php
 
-# reset the admin password to default (spotweb)
-s6-setuidgid abc php /app/bin/upgrade-db.php --reset-password admin
+if [ $(mysql --user=$mysql_user --password=$mysql_pass --host=$mysql_host --port=$mysql_port $mysql_db -sse "select count(*) from users where username = 'admin' and lastlogin = 0;") -eq 1 ];
+then
+    echo "Admin has not logged in, set default password"
+    s6-setuidgid abc php /app/bin/upgrade-db.php --reset-password admin
+else
+    echo "Admin has already logged in, no need to set default password"
+fi

--- a/x86/Dockerfile
+++ b/x86/Dockerfile
@@ -23,6 +23,7 @@ RUN apk -U update && \
         php7-json \
         php7-mbstring \
         php7-ctype \
+        mysql-client \
     && \
     git clone --depth 1 https://github.com/spotweb/spotweb.git /app && \
     sed -i "s/;date.timezone =/date.timezone = \"Europe\/Amsterdam\"/g" /etc/php7/php.ini


### PR DESCRIPTION
### What has been done
- Only reset the "admin" password to "spotweb" when the admin has never logged in (this is done so you can actually login without having to configure Spotweb yourself). Before the password was reset on every restart of the container, this is now solved, so you can change the admin password after the first login!