### PR TITLE
Fix FastCGI issues with Nginx

### DIFF
--- a/rootfs/etc/cont-init.d/30-config
+++ b/rootfs/etc/cont-init.d/30-config
@@ -3,3 +3,6 @@
 # permissions
 chown -R abc:abc \
 	/app
+
+# allow buffering of fastcgi responses
+chown -R abc:root /var/tmp/nginx

--- a/rootfs/etc/nginx/conf.d/default.conf
+++ b/rootfs/etc/nginx/conf.d/default.conf
@@ -26,6 +26,7 @@ server {
     #
     location ~ \.php$ {
         try_files $uri =404;
+        fastcgi_buffers 32 4k;
         fastcgi_split_path_info ^(.+\.php)(/.+)$;
         fastcgi_pass 127.0.0.1:9000;
         fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;


### PR DESCRIPTION
The docker image is serving incomplete responses for certain type of requests. 

When the response body of the php-fpm process doesn't fit into the default nginx `proxy_buffers` size, nginx tries to write a temporary file to `fastcgi_temp_path`.

Because of incorrect file permissions, this temporary file could not be created. This PR fixes the file permissions and increases the `fastcgi_buffers` size to a more realistic value.