### PR TITLE
Set HTTPS param based on X-Forwarded-Proto

### DIFF
--- a/rootfs/etc/nginx/conf.d/default.conf
+++ b/rootfs/etc/nginx/conf.d/default.conf
@@ -30,6 +30,7 @@ server {
         fastcgi_pass 127.0.0.1:9000;
         fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
         fastcgi_param SCRIPT_NAME $fastcgi_script_name;
+        fastcgi_param HTTPS $fastcgi_https;
         fastcgi_index index.php;
         include fastcgi_params;
     }

--- a/rootfs/etc/nginx/nginx.conf
+++ b/rootfs/etc/nginx/nginx.conf
@@ -25,5 +25,10 @@ http {
 
     gzip_types text/plain text/css application/json application/x-javascript text/xml application/xml application/xml+rss text/javascript application/javascript;
 
+    map $http_x_forwarded_proto $fastcgi_https {
+      default off;
+      "~https" on;
+    }
+
     include /etc/nginx/conf.d/*.conf;
 }


### PR DESCRIPTION
Sets the `HTTPS` parameter to be passed to the fastcgi process, based on the value of the `X-Forwarded-Proto` header.

This allows serving behind a reverse proxy with TLS termination.