### PR TITLE
Add SQLite support to init scripts, publish ENV vars in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,12 @@ LABEL maintainer "Erik de Vries <docker@erikdevries.nl>"
 # Disable timeout for starting services to make "wait for sql" work
 ENV S6_CMD_WAIT_FOR_SERVICES_MAXTIME=0
 ENV TZ=Europe/Amsterdam
+ENV DB_ENGINE=pdo_mysql
+ENV DB_HOST=mysql
+ENV DB_PORT=3306
+ENV DB_NAME=spotweb
+ENV DB_USER=spotweb
+ENV DB_PASS=spotweb
 # Default 5 minute interval configuration for Spotweb update cronjob
 ENV CRON_INTERVAL="*/5 * * * *"
 

--- a/README.md
+++ b/README.md
@@ -69,6 +69,25 @@ Included are example Docker Compose files, modify them as desired (e.g. change t
 - Change the `TZ` environment variable to any valid timezone (e.g. Europe/Amsterdam or Europe/Lisbon)
 - Restart the Spotweb Docker container
 
+## Use SQLite instead of MySQL
+
+SQLite is a light-weight serverless database engine and stores all content in a single file. Note that SQLite support in Spotweb is the least-tested database mode. Please report any issues to the [Spotweb project](https://github.com/spotweb/spotweb).
+
+- Change the `DB_ENGINE` variable to `pdo_sqlite`
+- Set the path to the database file in `DB_NAME`
+- Make sure, your database directory (or file) is mounted as a volume to not lose all data when the container is rebuilt
+
+```
+docker run -p 8085:80 \
+  --name spotweb -d \
+  -e DB_ENGINE=pdo_sqlite \
+  -e DB_NAME=/data/spotweb.db3 \
+  -v /local/path/to/spotweb-data:/data:rw \
+  erikdevries/spotweb
+```
+
+See `docker-compose-sqlite.yml` for an example Docker Compose setup.
+
 ## Tip: Using `ownsettings.php`
 
 You can override Spotweb settings by using a custom `ownsettings.php` file. In most cases there is no need to use this feature, so only use this when you know what you are doing!

--- a/docker-compose-sqlite.yml
+++ b/docker-compose-sqlite.yml
@@ -1,0 +1,19 @@
+version: '3'
+services:
+  spotweb:
+    image: erikdevries/spotweb
+    environment:
+      TZ: Europe/Amsterdam
+      DB_ENGINE: pdo_sqlite
+      DB_NAME: /data/spotweb.db3
+      CRON_INTERVAL: '*/5 * * * *'
+    ports:
+      - '8085:80'
+    depends_on:
+      - 'mysql'
+    volumes:
+      - dbdata:/data
+    #   - ./cache:/app/cache
+
+volumes:
+  dbdata:

--- a/docker-compose-sqlite.yml
+++ b/docker-compose-sqlite.yml
@@ -9,8 +9,6 @@ services:
       CRON_INTERVAL: '*/5 * * * *'
     ports:
       - '8085:80'
-    depends_on:
-      - 'mysql'
     volumes:
       - dbdata:/data
     #   - ./cache:/app/cache

--- a/rootfs/etc/cont-init.d/35-waitforsql
+++ b/rootfs/etc/cont-init.d/35-waitforsql
@@ -1,10 +1,12 @@
 #!/command/with-contenv bash
 
-mysql_host="${DB_HOST:-mysql}"
-mysql_port="${DB_PORT:-3306}"
-
-until nc -z -v -w30 $mysql_host $mysql_port
-do
-  echo "Waiting (5 seconds) for database connection at host '$mysql_host:$mysql_port'..."
-  sleep 5
-done
+if [ "${DB_ENGINE:-pdo_mysql}" = "pdo_mysql" ]; then
+  mysql_host="${DB_HOST:-mysql}"
+  mysql_port="${DB_PORT:-3306}"
+    
+  until nc -z -v -w30 $mysql_host $mysql_port
+  do
+    echo "Waiting (5 seconds) for database connection at host '$mysql_host:$mysql_port'..."
+    sleep 5
+  done
+fi

--- a/rootfs/etc/cont-init.d/40-initialize-db
+++ b/rootfs/etc/cont-init.d/40-initialize-db
@@ -1,18 +1,33 @@
 #!/command/with-contenv bash
 
-mysql_host="${DB_HOST:-mysql}"
-mysql_port="${DB_PORT:-3306}"
-mysql_user="${DB_USER:-spotweb}"
-mysql_pass="${DB_PASS:-spotweb}"
-mysql_db="${DB_NAME:-spotweb}"
+if [ "${DB_ENGINE:-pdo_mysql}" = "pdo_sqlite" ]; then
+  # Make sure database directory and file exist
+  sql_dir=$(dirname "${DB_NAME}")
+  mkdir -p "$sql_dir"
+  chown abc: "$sql_dir"
+  touch "${DB_NAME}"
+  chown abc: "${DB_NAME}"
+fi
 
-# upgrade the db
+# init/upgrade the db
 s6-setuidgid abc php82 /app/bin/upgrade-db.php
 
-if [ $(mysql --user=$mysql_user --password=$mysql_pass --host=$mysql_host --port=$mysql_port $mysql_db -sse "select count(*) from users where username = 'admin' and lastlogin = 0;") -eq 1 ];
+if [ "${DB_ENGINE:-pdo_mysql}" = "pdo_mysql" ]; then
+  mysql_host="${DB_HOST:-mysql}"
+  mysql_port="${DB_PORT:-3306}"
+  mysql_user="${DB_USER:-spotweb}"
+  mysql_pass="${DB_PASS:-spotweb}"
+  mysql_db="${DB_NAME:-spotweb}"
+
+  admin_login_count=$(mysql --user=$mysql_user --password=$mysql_pass --host=$mysql_host --port=$mysql_port $mysql_db -sse "select count(*) from users where username = 'admin' and lastlogin = 0;")
+elif [ "${DB_ENGINE}" = "pdo_sqlite" ]; then
+  admin_login_count=$(s6-setuidgid abc php82 -r "\$pdo = new PDO('sqlite:'.\$_ENV['DB_NAME']); \$res = \$pdo->query('SELECT count(*) FROM users WHERE username=\"admin\" AND lastlogin=0;')->fetchAll(); echo \$res[0][0];")
+fi
+
+if [ $admin_login_count -eq 1 ];
 then
-    echo "Admin has not logged in, set default password"
-    s6-setuidgid abc php82 /app/bin/upgrade-db.php --reset-password admin
+  echo "Admin has not logged in, set default password"
+  s6-setuidgid abc php82 /app/bin/upgrade-db.php --reset-password admin
 else
-    echo "Admin has already logged in, no need to set default password"
+  echo "Admin has already logged in, no need to set default password"
 fi

--- a/rootfs/etc/periodic/custom/spotweb
+++ b/rootfs/etc/periodic/custom/spotweb
@@ -1,12 +1,16 @@
 #!/bin/sh
 
-mysql_host="${DB_HOST:-mysql}"
-mysql_port="${DB_PORT:-3306}"
-mysql_user="${DB_USER:-spotweb}"
-mysql_pass="${DB_PASS:-spotweb}"
-mysql_db="${DB_NAME:-spotweb}"
+if [ "${DB_ENGINE:-pdo_mysql}" = "pdo_mysql" ]; then
+  mysql_host="${DB_HOST:-mysql}"
+  mysql_port="${DB_PORT:-3306}"
+  mysql_user="${DB_USER:-spotweb}"
+  mysql_pass="${DB_PASS:-spotweb}"
+  mysql_db="${DB_NAME:-spotweb}"
 
-nntp_servers=`mysql --user=$mysql_user --password=$mysql_pass --host=$mysql_host --port=$mysql_port $mysql_db -sse "select count(*) from settings where (name = 'nntp_nzb' or name = 'nntp_hdr') and value not like '%s:4:\"host\";s:0:\"\"%';"`
+  nntp_servers=`mysql --user=$mysql_user --password=$mysql_pass --host=$mysql_host --port=$mysql_port $mysql_db -sse "select count(*) from settings where (name = 'nntp_nzb' or name = 'nntp_hdr') and value not like '%s:4:\"host\";s:0:\"\"%';"`
+elif [ "${DB_ENGINE}" = "pdo_sqlite" ]; then
+  nntp_servers=$(s6-setuidgid abc php82 -r "\$pdo = new PDO('sqlite:'.\$_ENV['DB_NAME']); \$res = \$pdo->query('SELECT count(*) FROM settings WHERE (name = \'nntp_nzb\' OR name = \'nntp_hdr\') AND value NOT LIKE \'%s:4:\"host\";s:0:\"\"%\';')->fetchAll(); echo \$res[0][0];")
+fi
 
 if [ "$nntp_servers" -eq 0 ];
 then


### PR DESCRIPTION
I've added SQLite support to the init scripts. Before, even with `DB_ENGINE` set to `pdo_sqlite`, the init system was still waiting for MySQL to start and thus didn't finish. For SQLite, it now makes sure the desired path exists and file and path have the correct permissions.

I've also added the `ENV` entries to the Dockerfile, so the variables get propagated with the default values if not overridden by the user.

Tested with:

* `DB_ENGINE` = `pdo_sqlite`
* `DB_NAME` = `/data/spotweb.db3`
