### PR TITLE
Image size optimisations

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -47,7 +47,9 @@ RUN apk --no-cache upgrade && \
         php83-session \
         s6-overlay \
     && \
-    git clone --depth=1 https://github.com/spotweb/spotweb.git /app
+    git clone --depth=1 https://github.com/spotweb/spotweb.git /app \
+    && \
+    rm -rf /app/.git
 
 # Configure Spotweb
 COPY ./conf/spotweb /app

--- a/Dockerfile
+++ b/Dockerfile
@@ -49,10 +49,6 @@ RUN apk -U update && \
         php83-ctype \
         php83-opcache \
         php83-session \
-        mysql-client \
-        mariadb-connector-c \
-        postgresql-client \
-        sqlite \
         s6-overlay \
     && \
     git clone --depth=1 https://github.com/spotweb/spotweb.git /app

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,9 +13,8 @@ ENV DB_PASS=spotweb
 # Default 5 minute interval configuration for Spotweb update cronjob
 ENV CRON_INTERVAL="*/5 * * * *"
 
-RUN apk -U update && \
-    apk -U upgrade && \
-    apk -U add --no-cache \
+RUN apk --no-cache upgrade && \
+    apk --no-cache add \
         bash \
         coreutils \
         ca-certificates \

--- a/Dockerfile
+++ b/Dockerfile
@@ -37,12 +37,9 @@ RUN apk -U update && \
         php83-zlib \
         php83-gd \
         php83-openssl \
-        php83-mysqli \
         php83-pdo \
         php83-pdo_mysql \
-        php83-pgsql \
         php83-pdo_pgsql \
-        php83-sqlite3 \
         php83-pdo_sqlite \
         php83-json \
         php83-mbstring \

--- a/conf/spotweb/query.php
+++ b/conf/spotweb/query.php
@@ -1,0 +1,79 @@
+#!/usr/bin/env php
+<?php
+
+error_reporting(2147483647);
+
+try {
+    require_once __DIR__.'/vendor/autoload.php';
+
+    /*
+     * Initialize the Spotweb base classes
+     */
+    $bootstrap = new Bootstrap();
+    list($settings, $daoFactory, $req) = $bootstrap->boot();
+
+    /*
+     * disable timing, all queries which are ran by retrieve this would make it use
+     * large amounts of memory
+     */
+    SpotTiming::disable();
+
+    // Initialize commandline arguments
+    SpotCommandline::initialize(['debug', 'get_nntp_configured', 'get_admin_lastlogin'], ['debug' => false, 'get_nntp_configured' => false, 'get_admin_lastlogin' => false]);
+
+    // Initialize translation to english
+    SpotTranslation::initialize('en_US');
+
+    /*
+     * Do we need to debuglog this session? Generates loads of
+     * output
+     */
+    $debugLog = SpotCommandline::get('debug');
+    if ($debugLog) {
+        SpotDebug::enable(SpotDebug::TRACE);
+    } else {
+        SpotDebug::disable();
+    } // if
+
+    // ACTUAL STUFF FOLLOWS HERE
+    $getNntpConfigured = SpotCommandline::get('get_nntp_configured');
+    $getAdminLastlogin = SpotCommandline::get('get_admin_lastlogin');
+    if ($getNntpConfigured) {
+        $settingsDao = $daoFactory->getSettingDao();
+        $settings = $settingsDao->getAllSettings();
+        $numConfigs = 0;
+        if (strlen(trim($settings['nntp_nzb']['host'])) > 0) {
+            $numConfigs++;
+        }
+        if (strlen(trim($settings['nntp_hdr']['host'])) > 0) {
+            $numConfigs++;
+        }
+        echo $numConfigs;
+    } elseif ($getAdminLastlogin) {
+        $userDao = $daoFactory->getUserDao();
+        $adminId = $userDao->findUserIdForName('admin');
+        $adminUser = $userDao->getUser($adminId);
+        echo $adminUser['lastlogin'];
+    } else {
+        echo 'Syntax: ' . $argv[0] . ' --get_nntp_configured|--get_admin_lastlogin' . PHP_EOL;
+    }
+
+} catch (DatabaseConnectionException $x) {
+    echo 'Unable to connect to database: '.$x->getMessage().PHP_EOL;
+} // catch
+
+catch (InvalidOwnSettingsSettingException $x) {
+    echo 'There is an error in your ownsettings.php'.PHP_EOL.PHP_EOL;
+    echo $x->getMessage().PHP_EOL;
+} // InvalidOwnSettingsSetting
+
+catch (Exception $x) {
+    echo PHP_EOL.PHP_EOL;
+    echo 'SpotWeb v'.SPOTWEB_VERSION.' on PHP v'.PHP_VERSION.' crashed'.PHP_EOL.PHP_EOL;
+    echo 'Fatal error occured:'.PHP_EOL;
+    echo '  '.$x->getMessage().PHP_EOL.PHP_EOL;
+    echo PHP_EOL.PHP_EOL;
+    echo $x->getTraceAsString();
+    echo PHP_EOL.PHP_EOL;
+    exit();
+} // catch

--- a/rootfs/etc/cont-init.d/40-initialize-db
+++ b/rootfs/etc/cont-init.d/40-initialize-db
@@ -13,15 +13,9 @@ fi
 s6-setuidgid abc php83 /app/bin/upgrade-db.php
 
 # Run query to check if admin has logged in
-if [ "${DB_ENGINE}" = "pdo_mysql" ]; then
-  admin_login_count=$(mysql --user=${DB_USER} --password=${DB_PASS} --host=${DB_HOST} --port=${DB_PORT} ${DB_NAME} -sse "select count(*) from users where username = 'admin' and lastlogin = 0;")
-elif [ "${DB_ENGINE}" = "pdo_pgsql" ]; then
-  admin_login_count=$(PGPASSWORD=${DB_PASS} psql -At --username=${DB_USER} --host=${DB_HOST} --port=${DB_PORT} --dbname=${DB_NAME} -c "select count(*) from users where username = 'admin' and lastlogin = 0;")
-elif [ "${DB_ENGINE}" = "pdo_sqlite" ]; then
-  admin_login_count=$(echo "select count(*) from users where username = 'admin' and lastlogin = 0;" | sqlite3 ${DB_NAME})
-fi
+admin_lastlogin=$(s6-setuidgid abc php83 /app/query.php --get_admin_lastlogin)
 
-if [ $admin_login_count -eq 1 ];
+if [ $admin_lastlogin -eq 0 ];
 then
   echo "Admin has not logged in, set default password (which is: spotweb)"
   s6-setuidgid abc php83 /app/bin/upgrade-db.php --reset-password admin

--- a/rootfs/etc/periodic/custom/spotweb
+++ b/rootfs/etc/periodic/custom/spotweb
@@ -1,12 +1,6 @@
 #!/bin/sh
 
-if [ "${DB_ENGINE}" = "pdo_mysql" ]; then
-  nntp_servers=$(mysql --user=${DB_USER} --password=${DB_PASS} --host=${DB_HOST} --port=${DB_PORT} ${DB_NAME} -sse "select count(*) from settings where (name = 'nntp_nzb' or name = 'nntp_hdr') and value not like '%s:4:\"host\";s:0:\"\"%';")
-elif [ "${DB_ENGINE}" = "pdo_pgsql" ]; then
-  nntp_servers=$(PGPASSWORD=${DB_PASS} psql -At --username=${DB_USER} --host=${DB_HOST} --port=${DB_PORT} --dbname=${DB_NAME} -c "select count(*) from settings where (name = 'nntp_nzb' or name = 'nntp_hdr') and value not like '%s:4:\"host\";s:0:\"\"%';")
-elif [ "${DB_ENGINE}" = "pdo_sqlite" ]; then
-  nntp_servers=$(echo "select count(*) from settings where (name = 'nntp_nzb' or name = 'nntp_hdr') and value not like '%s:4:\"host\";s:0:\"\"%';" | sqlite3 ${DB_NAME})
-fi
+nntp_servers=$(s6-setuidgid abc php83 /app/query.php --get_nntp_configured)
 
 if [ "$nntp_servers" -eq 0 ]; then
   echo "NNTP server not configured, skipping retrieval of new headers"


### PR DESCRIPTION
Added `query.php` (based on Spotweb's `retrieve.php`) to use Spotweb's PHP-native database access to pull information about NNTP servers and admin user. No need for the db-specific tools - so removed them.

Removed non-PDO db extensions from PHP (Spotweb only uses PDO).

Removed `.git` folder after clone.

Fixed usage of `apk --no-cache` (which implies `apk update`) so nothing is left behind.

These optimisations reduced the image size for me (ARM64) from 202.5MB to 103.2MB.