### PR TITLE
Update base image to Alpine latest

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.19
+FROM alpine:latest
 LABEL maintainer "Erik de Vries <docker@erikdevries.nl>"
 
 # Disable timeout for starting services to make "wait for sql" work


### PR DESCRIPTION
Alpine 3.19 has quite a few [vulnerabilities](https://github.com/user-attachments/files/17056299/cve.txt), suggest to change Alpine version to `latest` instead of a specific version in the Dockerfile this will fix most of them.


```
  Target   │  erikdevries/spotweb:latest   
    digest │  9ae481953e28                 

## Recommended fixes

  Base image is  alpine:3.19 

  Name            │  3.19                                                                      
  Digest          │  sha256:a0264d60f80df12bc1e6dd98bae6c43debe6667c0ba482711f0d806493467a46   
  Vulnerabilities │    1C     1H     5M     0L     2?                                          
  Pushed          │ 7 months ago                                                               
  Size            │ 3.3 MB                                                                     
  Packages        │ 19                                                                         
  OS              │ 3.19.1                                                                     


Refresh base image
  Rebuild the image using a newer base image version. Updating this may result in breaking changes.


            Tag            │                        Details                        │   Pushed   │          Vulnerabilities            
───────────────────────────┼───────────────────────────────────────────────────────┼────────────┼─────────────────────────────────────
   3.19                    │ Benefits:                                             │ 1 week ago │    0C     0H     0M     0L          
  Newer image for same tag │ • Newer image for same tag                            │            │    -1     -1     -5            -2   
  Also known as:           │ • Patch OS version update                             │            │                                     
  • 3.19.4                 │ • Tag was pushed more recently                        │            │                                     
                           │ • Image has similar size                              │            │                                     
                           │ • Image introduces no new vulnerability but removes 7 │            │                                     
                           │ • Image contains equal number of packages             │            │                                     
                           │                                                       │            │                                     
                           │ Image details:                                        │            │                                     
                           │ • Size: 3.4 MB                                        │            │                                     
                           │ • OS: 3.19.4                                          │            │                                     
                           │                                                       │            │                                     
                           │                                                       │            │                                     
                           │                                                       │            │                                     


Change base image
  The list displays new recommended tags in descending order, where the top results are rated as most suitable.


          Tag          │                        Details                        │   Pushed   │          Vulnerabilities            
───────────────────────┼───────────────────────────────────────────────────────┼────────────┼─────────────────────────────────────
   3.20                │ Benefits:                                             │ 1 week ago │    0C     0H     0M     0L          
  Tag is preferred tag │ • Minor OS version update                             │            │    -1     -1     -5            -2   
  Also known as:       │ • Image contains 2 fewer packages                     │            │                                     
  • 3.20.3             │ • Tag is preferred tag                                │            │                                     
  • 3                  │ • Tag was pushed more recently                        │            │                                     
  • latest             │ • Tag is latest                                       │            │                                     
                       │ • Image introduces no new vulnerability but removes 7 │            │                                     
                       │                                                       │            │                                     
                       │ Image details:                                        │            │                                     
                       │ • Size: 4.1 MB                                        │            │                                     
                       │ • OS: 3.20.3                                          │            │                                     
                       │                                                       │            │                                     
                       │                                                       │            │                                     
                       │                                                       │            │                                     

```